### PR TITLE
add `disableFallbacks()` to disable development defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,16 @@ var config = getenv.multi({
 
 ```
 
+### env.disableFallbacks()
+
+Disallows fallbacks in environments where you don't want to rely on brittle development defaults (e.g production, integration testing). For example, to disable fallbacks if we indicate production via `NODE_ENV`:
+
+```javascript
+if (process.env.NODE_ENV === 'production') {
+  getenv.disableFallbacks();
+}
+```
+
 ## Changelog
 
 ### v0.3.0
@@ -115,6 +125,7 @@ var config = getenv.multi({
 - Christoph Tavan <dev@tavan.de>
 - Jonas Dohse <jonas@dohse.ch>
 - Jan Lehnardt (@janl): `getenv.multi()` support.
+- Tim Ruffles <timruffles@gmail.com>: `disableFallbacks()`
 
 ## License
 

--- a/lib/getenv.js
+++ b/lib/getenv.js
@@ -1,11 +1,17 @@
 var util = require("util");
 
+var fallbacksDisabled = false;
+
 function _value(varName, fallback) {
   var value = process.env[varName];
   if (value === undefined) {
     if (fallback === undefined) {
       throw new Error('GetEnv.Nonexistent: ' + varName + ' does not exist ' +
                       'and no fallback value provided.');
+    }
+    if (fallbacksDisabled) {
+      throw new Error('GetEnv.DisabledFallbacks: ' + varName + ' relying on fallback ' + 
+                      'when fallbacks have been disabled');
     }
     return '' + fallback;
   }
@@ -96,6 +102,10 @@ getenv.multi = function multi(spec) {
     }
   }
   return result;
+};
+
+getenv.disableFallbacks = function() {
+  fallbacksDisabled = true;
 };
 
 module.exports = getenv;

--- a/test/fallbacks.js
+++ b/test/fallbacks.js
@@ -1,0 +1,19 @@
+var assert = require('assert');
+
+var getenv = require('../lib/getenv');
+
+var tests = {};
+
+// order dependent test
+tests['getenv.disableFallbacks() makes relying on fallbacks an error'] = function() {
+  getenv.disableFallbacks();
+  assert.throws(function() {
+    getenv.string("url", "http://localhost");
+  });
+};
+
+
+Object.keys(tests).forEach(function(key) {
+  console.log('Test: %s', key);
+  tests[key]();
+});


### PR DESCRIPTION
relying on development defaults in production/integration environments
can be nasty. add a method to disable them, and document a common
pattern for doing so
