### PR TITLE
add url() support

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,16 @@ var config = getenv.multi({
 
 ```
 
+### env.url(name, [fallback])
+
+Return a parsed URL as per Node's `require("url").parse`. N.B `url` doesn't validate URLs, so be sure it includes a protocol or you'll get deeply weird results.
+
+```javascript
+var serviceUrl = getenv.url('SERVICE_URL');
+
+serviceUrl.port; // parsed port number
+```
+
 ### env.disableFallbacks()
 
 Disallows fallbacks in environments where you don't want to rely on brittle development defaults (e.g production, integration testing). For example, to disable fallbacks if we indicate production via `NODE_ENV`:
@@ -109,6 +119,9 @@ if (process.env.NODE_ENV === 'production') {
 ```
 
 ## Changelog
+
+### v0.5.0
+- Add getenv.url() support.
 
 ### v0.4.0
 - Add getenv.disableFallbacks() support.
@@ -128,7 +141,7 @@ if (process.env.NODE_ENV === 'production') {
 - Christoph Tavan <dev@tavan.de>
 - Jonas Dohse <jonas@dohse.ch>
 - Jan Lehnardt (@janl): `getenv.multi()` support.
-- Tim Ruffles <timruffles@gmail.com>: `disableFallbacks()`
+- Tim Ruffles <timruffles@gmail.com>: `disableFallbacks()`, `url()`
 
 ## License
 

--- a/lib/getenv.js
+++ b/lib/getenv.js
@@ -1,4 +1,5 @@
 var util = require("util");
+var url = require("url");
 
 var fallbacksDisabled = false;
 
@@ -50,7 +51,8 @@ var convert = {
     }
 
     return (value === 'true');
-  }
+  },
+  url: url.parse
 };
 
 function converter(type) {

--- a/test/getenv.js
+++ b/test/getenv.js
@@ -35,6 +35,10 @@ process.env.TEST_GETENV_BOOL_ARRAY_INVALID1 = 'true, 1, true';
 process.env.TEST_GETENV_BOOL_ARRAY_INVALID2 = 'true, 1.2, true';
 process.env.TEST_GETENV_BOOL_ARRAY_INVALID3 = 'true, abc, true';
 
+process.env.TEST_GETENV_URL_1 = "tcp://localhost:80";
+process.env.TEST_GETENV_URL_2 = "tcp://localhost:2993";
+process.env.TEST_GETENV_URL_3 = "http://192.162.22.11:2993";
+
 var tests = {};
 
 tests['getenv() same as getenv.string()'] = function() {
@@ -477,6 +481,26 @@ tests['getenv.multi([string/single/throw]) multiple env vars'] = function() {
   };
   assert.throws(function() {
     var config = getenv.multi(spec);
+  });
+};
+
+tests['getenv.url() valid input'] = function() {
+
+  var expected = [
+    {hostname: "localhost", port: "80", protocol: "tcp:"},
+    {hostname: "localhost", port: "2993", protocol: "tcp:"},
+    {hostname: "192.162.22.11", port: "2993", protocol: "http:"},
+  ];
+
+  var prefix = "TEST_GETENV_URL_";
+
+  expected.forEach(function(expectation, i) {
+    var parsed = getenv.url(prefix + (i + 1));
+    var actual = Object.keys(expectation).reduce(function(h, key) {
+      h[key] = parsed[key];
+      return h;
+    }, {});
+    assert.deepEqual(actual, expectation);
   });
 };
 


### PR DESCRIPTION
getting service URLs from env is a frequnt use-case. this makes it
easier and safer
- easier: fully parsed URLs
- easier: one env var to manage
- safer: validates for something sane, and avoids default ports
