### PR TITLE
Extend boolish by y/n and added separator parameter to array

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,11 @@ Return as boolean. Only allows true/false as valid values.
 
 ### env.boolish(name, [fallback])
 
-Return as boolean. Allows true/false/1/0 as valid values.
+Return as boolean. Allows true/false/1/0/y/n/Y/N as valid values.
 
-### env.array(name, [type], [fallback])
+### env.array(name, [type], [fallback], [separator])
 
-Split value of the environment variable at each comma and return the resulting array where each value has been typecast according to the `type` parameter. An array can be provided as `fallback`.
+Split value of the environment variable at each comma (default) and return the resulting array where each value has been typecast according to the `type` parameter. An array can be provided as `fallback` and a regular expression can be provided as `separator` in case commas don't fit.
 
 ### env.multi({spec})
 

--- a/index.js
+++ b/index.js
@@ -65,12 +65,15 @@ const convert = {
     try {
       return convert.bool(value);
     } catch (err) {
-      const isBool = value === '1' || value === '0';
+      const upperCaseValue = value.toUpperCase();
+      const isBool = value === '1' || value === '0' || upperCaseValue === 'Y' || upperCaseValue === 'N';
       if (!isBool) {
         throw new Error('GetEnv.NoBoolean: ' + value + ' is not a boolean.');
       }
-
-      return value === '1';
+      if (value === '1' || upperCaseValue === 'Y') {
+        return true;
+      };
+      return false;
     }
   },
   url: url.parse,
@@ -95,20 +98,22 @@ Object.keys(convert).forEach(function(type) {
   getenv[type] = converter(type);
 });
 
-getenv.array = function array(varName, type, fallback) {
+
+getenv.array = function array(varName, type, fallback, separator) {
   type = type || 'string';
+  separator = separator || /\s*,\s*/;
   if (Object.keys(convert).indexOf(type) === -1) {
     throw new Error('GetEnv.ArrayUndefinedType: Unknown array type ' + type);
   }
   const value = _value(varName, fallback);
-  return value.split(/\s*,\s*/).map(convert[type]);
+  return value.split(separator).map(convert[type]);
 };
 
 getenv.multi = function multi(spec) {
   const result = {};
   for (let key in spec) {
     const value = spec[key];
-    if (util.isArray(value)) {
+    if (Array.isArray(value)) {
       // default value & typecast
       switch (value.length) {
         case 1: // no default value

--- a/test/getenv.js
+++ b/test/getenv.js
@@ -16,21 +16,27 @@ process.env.TEST_GETENV_FALSE = 'false';
 process.env.TEST_GETENV_TRUE = 'true';
 process.env.TEST_GETENV_NOT_REALLY_TRUE = '1';
 process.env.TEST_GETENV_NOT_REALLY_FALSE = '0';
+process.env.TEST_GETENV_NOT_REALLY_TRUE2 = 'y';
+process.env.TEST_GETENV_NOT_REALLY_FALSE2 = 'n';
 process.env.TEST_GETENV_WRONG_NUMBER_INPUT = '3 test';
 process.env.TEST_GETENV_STRING_ARRAY1 = 'one';
 process.env.TEST_GETENV_STRING_ARRAY2 = 'one, two ,three , four';
 process.env.TEST_GETENV_STRING_ARRAY3 = 'one, two,';
 process.env.TEST_GETENV_STRING_ARRAY4 = ' ';
 process.env.TEST_GETENV_STRING_ARRAY5 = 'one;two:three,four';
+process.env.TEST_GETENV_STRING_ARRAY6 = 'one two ';
 process.env.TEST_GETENV_INT_ARRAY = '1,2, 3';
+process.env.TEST_GETENV_INT_ARRAY2 = '1  2 3';
 process.env.TEST_GETENV_INT_ARRAY_INVALID1 = '1, 2.2, 3';
 process.env.TEST_GETENV_INT_ARRAY_INVALID2 = '1, true, 3';
 process.env.TEST_GETENV_INT_ARRAY_INVALID3 = '1, abc, 3';
 process.env.TEST_GETENV_FLOAT_ARRAY = '1.9,2, 3e5';
+process.env.TEST_GETENV_FLOAT_ARRAY2 = '1.9 2  3e5';
 process.env.TEST_GETENV_FLOAT_ARRAY_INVALID1 = '1.9,true, 3e5';
 process.env.TEST_GETENV_FLOAT_ARRAY_INVALID2 = '1.9, abc, 3e5';
 process.env.TEST_GETENV_FLOAT_ARRAY_INVALID3 = '1.9, Infinity, 3e5';
 process.env.TEST_GETENV_BOOL_ARRAY = 'true, false, true';
+process.env.TEST_GETENV_BOOL_ARRAY2 = 'true n 1';
 process.env.TEST_GETENV_BOOL_ARRAY_INVALID1 = 'true, 1, true';
 process.env.TEST_GETENV_BOOL_ARRAY_INVALID2 = 'true, 1.2, true';
 process.env.TEST_GETENV_BOOL_ARRAY_INVALID3 = 'true, abc, true';
@@ -243,6 +249,14 @@ tests['getenv.boolish() valid input'] = function() {
       varName: 'TEST_GETENV_NOT_REALLY_TRUE',
       expected: true,
     },
+    {
+      varName: 'TEST_GETENV_NOT_REALLY_FALSE2',
+      expected: false,
+    },
+    {
+      varName: 'TEST_GETENV_NOT_REALLY_TRUE2',
+      expected: true,
+    },
   ];
 
   data.forEach(function(item) {
@@ -303,7 +317,37 @@ tests['getenv.array() valid string (default) input'] = function() {
 
   data.forEach(function(item) {
     const arrayVar = getenv.array(item.varName);
-    assert.deepEqual(arrayVar, item.expected);
+    assert.deepStrictEqual(arrayVar, item.expected);
+  });
+};
+
+tests['getenv.array() valid inputs split by separator'] = function() {
+  const data = [
+    {
+      varName: 'TEST_GETENV_STRING_ARRAY6',
+      type: 'string',
+      expected: ['one', 'two', ''],
+    },
+    {
+      varName: 'TEST_GETENV_INT_ARRAY2',
+      type: 'int',
+      expected: [1, 2, 3],
+    },
+    {
+      varName: 'TEST_GETENV_FLOAT_ARRAY2',
+      type: 'float',
+      expected: [1.9, 2, 3e5],
+    },
+    {
+      varName: 'TEST_GETENV_BOOL_ARRAY2',
+      type: 'boolish',
+      expected: [true, false, true],
+    },
+  ];
+
+  data.forEach(function(item) {
+    const arrayVar = getenv.array(item.varName, item.type, [], /\s+/);
+    assert.deepStrictEqual(arrayVar, item.expected);
   });
 };
 
@@ -411,7 +455,7 @@ tests['getenv.array() nonexistent variable'] = function() {
 tests['getenv.array() nonexistent variable with fallback'] = function() {
   const expect = ['A', 'B', 'C'];
   const arrayVar = getenv.array('TEST_GETENV_NONEXISTENT', 'string', expect);
-  assert.deepEqual(arrayVar, expect);
+  assert.deepStrictEqual(arrayVar, expect);
 };
 
 tests['getenv.array() nonexistent type'] = function() {
@@ -428,7 +472,7 @@ tests['getenv.multi([string]) multiple env vars'] = function() {
   const expect = {
     foo: process.env.TEST_GETENV_STRING,
   };
-  assert.deepEqual(expect, config);
+  assert.deepStrictEqual(expect, config);
 };
 
 tests['getenv([string]) multiple env vars shortcut'] = function() {
@@ -439,7 +483,7 @@ tests['getenv([string]) multiple env vars shortcut'] = function() {
   const expect = {
     foo: process.env.TEST_GETENV_STRING,
   };
-  assert.deepEqual(expect, config);
+  assert.deepStrictEqual(expect, config);
 };
 
 tests['getenv.multi([string/throw]) multiple env vars'] = function() {
@@ -459,7 +503,7 @@ tests['getenv.multi([string/typecast]) multiple env vars'] = function() {
   const expect = {
     foo: process.env.TEST_GETENV_STRING,
   };
-  assert.deepEqual(expect, config);
+  assert.deepStrictEqual(expect, config);
 };
 
 tests['getenv.multi([string/typecast/defaultval]) multiple env vars'] = function() {
@@ -470,7 +514,7 @@ tests['getenv.multi([string/typecast/defaultval]) multiple env vars'] = function
   const expect = {
     foo: 'default',
   };
-  assert.deepEqual(expect, config);
+  assert.deepStrictEqual(expect, config);
 };
 
 tests['getenv.multi([string/typecast/throw]) multiple env vars'] = function() {
@@ -490,7 +534,7 @@ tests['getenv.multi([string/defaultval]) multiple env vars'] = function() {
   const expect = {
     foo: process.env.TEST_GETENV_STRING,
   };
-  assert.deepEqual(expect, config);
+  assert.deepStrictEqual(expect, config);
 };
 
 tests['getenv.multi([string/defaultval/throw]) multiple env vars'] = function() {
@@ -501,7 +545,7 @@ tests['getenv.multi([string/defaultval/throw]) multiple env vars'] = function() 
   const expect = {
     foo: 'default',
   };
-  assert.deepEqual(expect, config);
+  assert.deepStrictEqual(expect, config);
 };
 
 tests['getenv.multi([string/single]) multiple env vars'] = function() {
@@ -512,7 +556,7 @@ tests['getenv.multi([string/single]) multiple env vars'] = function() {
   const expect = {
     foo: process.env.TEST_GETENV_STRING,
   };
-  assert.deepEqual(expect, config);
+  assert.deepStrictEqual(expect, config);
 };
 
 tests['getenv.multi([string/single/throw]) multiple env vars'] = function() {
@@ -539,7 +583,7 @@ tests['getenv.url() valid input'] = function() {
       h[key] = parsed[key];
       return h;
     }, {});
-    assert.deepEqual(actual, expectation);
+    assert.deepStrictEqual(actual, expectation);
   });
 };
 


### PR DESCRIPTION
Hi,

I exended the library by two things I find useful.

- The `boolish` function now also accepts `Y`, `y`, `N`, `n` (for yes = true and no = false) as values.
- The array function accepts the string separator regex as optional parameter. Default is the unchanged regex for spaces.

Please merge the PR if you find it useful too.
